### PR TITLE
add missing license header to make build succeed

### DIFF
--- a/src/main/java/net/satago/tapestry5/jpa/misc/Workaround_TAP5_2499.java
+++ b/src/main/java/net/satago/tapestry5/jpa/misc/Workaround_TAP5_2499.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Satago Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.satago.tapestry5.jpa.misc;
 
 import java.util.Map;


### PR DESCRIPTION
I've fixed TAP5-2499 already but just cleaning up everything before merging to T5.
