### PR TITLE
Remove copyright notices from file license header, add a NOTICE.txt noting the copyrights

### DIFF
--- a/LICENSE-HEADER
+++ b/LICENSE-HEADER
@@ -1,5 +1,3 @@
-Copyright 2015 Satago Ltd.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,13 @@
+This product includes software developed by
+Satago Ltd (https://www.satago.com/).
+
+Copyright 2015 Satago Ltd.
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This software depends on the Java Persistence API, developed by the EJB 3.0
+software expert group as part of JSR 220.
+See http://www.oracle.com/technetwork/java/javaee/tech/persistence-jsp-140049.html
+for more information. Various JPA implementations are licensed under terms provided
+by each respective JPA provider.

--- a/src/main/java/net/satago/tapestry5/jpa/TapestryCDIBeanManagerForJPAEntityListeners.java
+++ b/src/main/java/net/satago/tapestry5/jpa/TapestryCDIBeanManagerForJPAEntityListeners.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/TransactionalUnit.java
+++ b/src/main/java/net/satago/tapestry5/jpa/TransactionalUnit.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/TransactionalUnits.java
+++ b/src/main/java/net/satago/tapestry5/jpa/TransactionalUnits.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/TransactionalUnitsModule.java
+++ b/src/main/java/net/satago/tapestry5/jpa/TransactionalUnitsModule.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/NoopAnnotatedType.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/NoopAnnotatedType.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/NoopBeanManager.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/NoopBeanManager.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/NoopCreationalContext.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/NoopCreationalContext.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/NoopInjectionTarget.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/NoopInjectionTarget.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitJpaTransactionAdvisor.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitJpaTransactionAdvisor.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitMethodAdvice.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitMethodAdvice.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitWorker.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitWorker.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitsImpl.java
+++ b/src/main/java/net/satago/tapestry5/jpa/internal/TransactionalUnitsImpl.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/satago/tapestry5/jpa/misc/Workaround_TAP5_2499.java
+++ b/src/main/java/net/satago/tapestry5/jpa/misc/Workaround_TAP5_2499.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2015 Satago Ltd.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Here are the suggested changes with copyright notices removed from the individual files and with an an ASF style NOTICE file added (Tapestry uses .txt suffix but it's not required). Accept if you agree (and sorry I totally unnecessarily fetched and rebased on top of upstream, causing duplicate commit markers, should have cleaned the history before pushing).
